### PR TITLE
Fix nonce timestamp format mismatch

### DIFF
--- a/DigestAuthentication.Implementation/DigestAuthImplementation.cs
+++ b/DigestAuthentication.Implementation/DigestAuthImplementation.cs
@@ -126,7 +126,7 @@ namespace FlakeyBit.DigestAuthentication.Implementation
 
         private string CreateNonce(DateTime timestamp) {
             var builder = new StringBuilder();
-            var timestampStr = timestamp.ToString(NonceTimestampFormat);
+            var timestampStr = timestamp.ToString(NonceTimestampFormat, CultureInfo.InvariantCulture);
             builder.Append(timestampStr);
             builder.Append(" ");
             builder.Append($"{timestampStr}:{_config.ServerNonceSecret}".ToMD5Hash());


### PR DESCRIPTION
The current culture is used to create a string version of the timestamp, but ParseTimestamp uses CultureInfo.InvariantCulture to parse it. If the current culture differs from invariant the parsed timestamp will be wrong, and the timestamp delta will be too large. This leads to never-ending Digest challenges, with the password never accepted.

To reproduce the issue launch `Intl.cpl` and set the date format to "Thai (Thailand)", then restart the web server.